### PR TITLE
Feature/honor enabled false

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2308,7 +2308,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2329,12 +2330,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2349,17 +2352,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2476,7 +2482,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2488,6 +2495,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2502,6 +2510,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2509,12 +2518,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2533,6 +2544,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2613,7 +2625,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2625,6 +2638,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2710,7 +2724,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2746,6 +2761,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2765,6 +2781,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2808,12 +2825,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -59,13 +59,17 @@ class OfflineScheduler {
       const { events } = functionConfig;
       const scheduleEvents = events.filter(event => event.hasOwnProperty('schedule'));
 
-      return scheduleEvents.map(event => {
-        return {
-          functionName,
-          cron: convertExpressionToCron(event['schedule'].rate),
-          input: event['schedule'].input || {},
-        };
-      });
+      return scheduleEvents
+        .filter(
+          event => !event.schedule.hasOwnProperty('enabled') || event.schedule.enabled === true
+        )
+        .map(event => {
+          return {
+            functionName,
+            cron: convertExpressionToCron(event['schedule'].rate),
+            input: event['schedule'].input || {},
+          };
+        });
     });
 
     return flatten(scheduleConfigurations);

--- a/tests/scheduler.spec.ts
+++ b/tests/scheduler.spec.ts
@@ -39,7 +39,7 @@ describe('OfflineScheduler', () => {
     expect(log).toBeCalledTimes(0);
   });
 
-  const scheduleFunction = {
+  const enabledScheduleFunction = {
     'schedule-function': {
       handler: 'src/functions/schedule-function.handler',
       events: [
@@ -47,6 +47,14 @@ describe('OfflineScheduler', () => {
           schedule: {
             name: '1-minute',
             rate: 'rate(1 minute)',
+            input: { scheduler: '1-minute' },
+          },
+        },
+        {
+          schedule: {
+            name: '1-minute',
+            rate: 'rate(1 minute)',
+            enabled: true,
             input: { scheduler: '1-minute' },
           },
         },
@@ -60,14 +68,19 @@ describe('OfflineScheduler', () => {
     const scheduleJob = jest.spyOn(schedule, 'scheduleJob');
     const scheduler = new Scheduler({
       log,
-      functionProvider: () => scheduleFunction,
+      functionProvider: () => enabledScheduleFunction,
     });
 
     scheduler.scheduleEvents();
-    expect(log).toBeCalledWith(
+    expect(log).nthCalledWith(
+      1,
       'Scheduling [schedule-function] cron: [*/1 * * * *] input: {"scheduler":"1-minute"}'
     );
-    expect(scheduleJob).toBeCalledTimes(1);
+    expect(log).nthCalledWith(
+      2,
+      'Scheduling [schedule-function] cron: [*/1 * * * *] input: {"scheduler":"1-minute"}'
+    );
+    expect(scheduleJob).toBeCalledTimes(2);
   });
 
   const disabledScheduleFunction = {
@@ -78,7 +91,7 @@ describe('OfflineScheduler', () => {
           schedule: {
             name: '1-minute',
             rate: 'rate(1 minute)',
-            disabled: false,
+            enabled: false,
             input: { scheduler: '1-minute' },
           },
         },
@@ -96,11 +109,24 @@ describe('OfflineScheduler', () => {
     });
 
     scheduler.scheduleEvents();
-    expect(log).toBeCalledWith(
-      'Scheduling [schedule-function] cron: [*/1 * * * *] input: {"scheduler":"1-minute"}'
-    );
-    expect(scheduleJob).toBeCalledTimes(1);
+    expect(log).toBeCalledTimes(0);
   });
+
+  const scheduleFunction = {
+    'schedule-function': {
+      handler: 'src/functions/schedule-function.handler',
+      events: [
+        {
+          schedule: {
+            name: '1-minute',
+            rate: 'rate(1 minute)',
+            input: { scheduler: '1-minute' },
+          },
+        },
+      ],
+      name: 'my-service-dev-schedule-function',
+    },
+  };
 
   it('Should schedule job in standalone process when function with schedule provided', () => {
     const log = jest.fn();

--- a/tests/scheduler.spec.ts
+++ b/tests/scheduler.spec.ts
@@ -70,6 +70,38 @@ describe('OfflineScheduler', () => {
     expect(scheduleJob).toBeCalledTimes(1);
   });
 
+  const disabledScheduleFunction = {
+    'schedule-function': {
+      handler: 'src/functions/schedule-function.handler',
+      events: [
+        {
+          schedule: {
+            name: '1-minute',
+            rate: 'rate(1 minute)',
+            disabled: false,
+            input: { scheduler: '1-minute' },
+          },
+        },
+      ],
+      name: 'my-service-dev-schedule-function',
+    },
+  };
+
+  it('Should not schedule job when function with enabled=false provided', () => {
+    const log = jest.fn();
+    const scheduleJob = jest.spyOn(schedule, 'scheduleJob');
+    const scheduler = new Scheduler({
+      log,
+      functionProvider: () => disabledScheduleFunction,
+    });
+
+    scheduler.scheduleEvents();
+    expect(log).toBeCalledWith(
+      'Scheduling [schedule-function] cron: [*/1 * * * *] input: {"scheduler":"1-minute"}'
+    );
+    expect(scheduleJob).toBeCalledTimes(1);
+  });
+
   it('Should schedule job in standalone process when function with schedule provided', () => {
     const log = jest.fn();
     const scheduleJob = jest.spyOn(schedule, 'scheduleJob');

--- a/typings/Serverless/index.d.ts
+++ b/typings/Serverless/index.d.ts
@@ -35,7 +35,7 @@ declare namespace Serverless {
     extraServicePath?: string;
   }
 
-  type Event = { [type: string]: { rate: string; input?: object } };
+  type Event = { [type: string]: { rate: string; input?: object; enabled?: boolean } };
 
   interface Function {
     handler: string;


### PR DESCRIPTION
Hi Meemaw

This is a minor PR for sls-offline-schedule to honor the enabled=false attribute in scheduled events.

All it does is to filter out scheduled events that are enabled=false. When enabled=true, or when enabled is not defined, the events are scheduled as usual.

One unit test is updated and one is created, to test that when enabled=true, events are scheduled and when false, disabled.

This is tested with old versions of serverless and serverless-offline as well. Hope these does not affect this PR. I will be stuck with these antiquated packages for quite a while, sadly, sigh:
    "serverless": "1.40.0",
    "serverless-offline": "5.10.1",

Looking forward to your feedback.
Best
Joe